### PR TITLE
Split mac_setup.sh into personal and work setup scripts

### DIFF
--- a/bin/mac_setup.sh
+++ b/bin/mac_setup.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set +x
 ## /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/anshprat/myfiles/master/bin/mac_setup.sh)"
+##
+## DEPRECATED: superseded by the split setup —
+##   bin/mac_setup_personal.sh  (every laptop: identity + apps)
+##   bin/mac_setup_work.sh      (work laptop: cloud/k8s/IaC + runtimes)
+## Kept temporarily for reference; remove once the split is validated.
 
 echo "update timestamp_timeout (value is in minutes) using sudo visudo to avoid entering sudo password continuously"
 

--- a/bin/mac_setup_personal.sh
+++ b/bin/mac_setup_personal.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# mac_setup_personal.sh — personal macOS setup that follows me across laptops.
+#
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/anshprat/myfiles/master/bin/mac_setup_personal.sh)"
+#
+# This is the "who I am on any machine" half of the setup. Work-specific
+# tooling (cloud / k8s / IaC + extra runtimes) lives in mac_setup_work.sh,
+# and the loom dev loop is provisioned by loom's scripts/setup-dev-env.sh.
+#
+# Idempotent: safe to re-run. Each step skips work that's already done; a
+# failing step is recorded and skipped (summarized at the end, non-zero exit)
+# rather than aborting the whole run.
+
+set -uo pipefail
+
+# --- helpers -----------------------------------------------------------------
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mWARN:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+has()  { command -v "$1" >/dev/null 2>&1; }
+
+FAILED_COUNT=0
+FAILED_LIST=""
+note_fail() {
+  warn "$1 — continuing with the remaining steps."
+  FAILED_COUNT=$((FAILED_COUNT + 1))
+  FAILED_LIST="${FAILED_LIST}  - $1\n"
+}
+
+# Install a formula only if it isn't already present. Tap-qualified names
+# (foo/bar/baz) are checked by their final component.
+brew_install() {
+  local formula="$1"
+  brew list "${formula##*/}" >/dev/null 2>&1 || brew install "$formula"
+}
+
+# Install a cask only if it isn't already present.
+brew_install_cask() {
+  local cask="$1"
+  brew list --cask "${cask##*/}" >/dev/null 2>&1 || brew install --cask "$cask"
+}
+
+# Open the Mac App Store page for an app that brew can't install (e.g. when the
+# App Store build is the one we want — Bitwarden's Touch ID Safari extension).
+appstore_if_missing() {
+  local app="$1" url="$2"
+  [[ -d "/Applications/$app" ]] || { warn "$app needs a Mac App Store install"; open "$url"; }
+}
+
+# --- 1. Homebrew --------------------------------------------------------------
+
+info "Step 1/8: Homebrew"
+if ! has brew; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
+    || die "Homebrew installation failed."
+fi
+BREW_BIN="/opt/homebrew/bin/brew"
+[[ -x "$BREW_BIN" ]] || BREW_BIN="/usr/local/bin/brew"
+has brew || eval "$("$BREW_BIN" shellenv)"
+grep -qxF "eval \"\$($BREW_BIN shellenv)\"" "$HOME/.zprofile" 2>/dev/null \
+  || echo "eval \"\$($BREW_BIN shellenv)\"" >> "$HOME/.zprofile"
+has brew || die "Homebrew is not on PATH after install"
+
+# --- 2. Directories + screenshots symlink -------------------------------------
+
+info "Step 2/8: directories + screenshots symlink"
+mkdir -p ~/tmp/screenshots ~/code/{grab,anshprat,others}
+[[ -L "$HOME/Desktop/screenshots" ]] || ln -sv ~/tmp/screenshots ~/Desktop/screenshots
+
+# --- 3. Taps ------------------------------------------------------------------
+
+info "Step 3/8: taps"
+brew tap dopplerhq/cli      >/dev/null 2>&1 || note_fail "tap dopplerhq/cli failed"
+brew tap teamookla/speedtest >/dev/null 2>&1 || note_fail "tap teamookla/speedtest failed"
+
+# --- 4. CLI formulae ----------------------------------------------------------
+
+info "Step 4/8: CLI tools"
+PERSONAL_FORMULAE=(
+  curl wget git
+  jq yq ripgrep fzf tree htop
+  stow direnv gh pipx
+  imagemagick terminal-notifier displayplacer
+  doppler                       # secrets manager (all secrets live in Doppler)
+  teamookla/speedtest/speedtest
+  awscli certbot                # review: move to mac_setup_work.sh if AWS/certs are work-only
+)
+for pkg in "${PERSONAL_FORMULAE[@]}"; do
+  brew_install "$pkg" || note_fail "brew install $pkg failed"
+done
+
+# --- 5. GUI apps (casks) ------------------------------------------------------
+
+info "Step 5/8: GUI apps"
+PERSONAL_CASKS=(
+  google-chrome firefox          # browsers
+  1password                      # password manager (Bitwarden via App Store below for Touch ID)
+  dropbox telegram whatsapp      # comms / sync
+  obsidian notion                # notes
+  ghostty                        # terminal
+  secretive                      # SSH keys in the Secure Enclave
+  shottr                         # screenshots (pairs with ~/Desktop/screenshots)
+  caffeine hiddenbar stats rectangle xbar   # menubar / window utilities
+  adobe-acrobat-reader gimp postman
+)
+for cask in "${PERSONAL_CASKS[@]}"; do
+  brew_install_cask "$cask" || note_fail "brew install --cask $cask failed"
+done
+
+# Bitwarden: the Mac App Store build carries the Touch ID Safari extension that
+# the cask doesn't, so keep installing it from the App Store.
+appstore_if_missing "Bitwarden.app" "https://apps.apple.com/sg/app/bitwarden/id1352778147?mt=12"
+
+xcode-select --install 2>/dev/null \
+  || info 'Command line tools already installed (use "Software Update" for updates).'
+
+# --- 6. dotfiles repo + ~/bin -------------------------------------------------
+# NOTE: the old Keybase-based dotfiles/.ssh flow is gone. SSH keys now come from
+# Secretive (Secure Enclave) and secrets from Doppler / 1Password / Bitwarden.
+
+info "Step 6/8: myfiles repo + ~/bin symlink"
+mkdir -p ~/code/anshprat
+if [[ ! -d ~/code/anshprat/myfiles ]]; then
+  if git clone https://github.com/anshprat/myfiles.git ~/code/anshprat/myfiles; then
+    git -C ~/code/anshprat/myfiles remote set-url origin git@github.com:anshprat/myfiles.git
+  else
+    note_fail "cloning myfiles failed"
+  fi
+fi
+[[ -L ~/bin ]] || ln -s ~/code/anshprat/myfiles/bin ~/bin
+
+# --- 7. oh-my-zsh + custom.zsh ------------------------------------------------
+# powerlevel10k is intentionally NOT installed here. If you keep it, note that
+# zshrc sources $(brew --prefix)/share/powerlevel10k/powerlevel10k.zsh-theme —
+# that line will error until `brew install powerlevel10k` is run by hand.
+
+info "Step 7/8: oh-my-zsh"
+[[ -d ~/.oh-my-zsh ]] \
+  || sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended \
+  || note_fail "oh-my-zsh install failed"
+
+CUSTOM_DEST="$HOME/.oh-my-zsh/custom/custom.zsh"
+if [[ ! -e "$CUSTOM_DEST" ]]; then
+  info "linking $CUSTOM_DEST -> myfiles/zshrc"
+  ln -s "$HOME/code/anshprat/myfiles/zshrc" "$CUSTOM_DEST"
+fi
+
+# --- 8. downloads_organizer cron ----------------------------------------------
+
+info "Step 8/8: downloads_organizer cron"
+CRON_CMD="$HOME/bin/downloads_organizer"
+CRON_JOB="3 * * * *  $CRON_CMD"
+current_cron="$(crontab -l 2>/dev/null || true)"
+if ! grep -qF "$CRON_CMD" <<<"$current_cron"; then
+  if {
+      [[ "$current_cron" == *'MAILTO='* ]] || echo 'MAILTO=""'
+      [[ -n "$current_cron" ]] && printf '%s\n' "$current_cron"
+      echo "$CRON_JOB"
+    } | crontab -; then
+    info "Added downloads_organizer cron — grant Full Disk Access to cron in System Settings > Privacy."
+  else
+    note_fail "installing downloads_organizer cron failed"
+  fi
+fi
+
+# --- summary ------------------------------------------------------------------
+
+echo
+if [[ "$FAILED_COUNT" -gt 0 ]]; then
+  warn "Personal setup finished with $FAILED_COUNT issue(s):"
+  printf '%b' "$FAILED_LIST" >&2
+  warn "The script is idempotent — fix the issues above and re-run it."
+else
+  info "All personal setup steps completed."
+fi
+echo "On a work laptop, run bin/mac_setup_work.sh next (and loom's scripts/setup-dev-env.sh for the loom dev loop)."
+
+[[ "$FAILED_COUNT" -eq 0 ]] || exit 1

--- a/bin/mac_setup_work.sh
+++ b/bin/mac_setup_work.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# mac_setup_work.sh — work-laptop-only tooling (cloud / k8s / IaC + runtimes).
+#
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/anshprat/myfiles/master/bin/mac_setup_work.sh)"
+#
+# Division of responsibility:
+#   - mac_setup_personal.sh ............ identity + apps for every laptop
+#   - loom scripts/setup-dev-env.sh .... the loom dev loop (Homebrew, pnpm/just/
+#                                        git/direnv/tmux/yq/jq, Node 24.15 via
+#                                        nvm, pm2, shll/fab, Docker, ghcr auth,
+#                                        clone loom) — run that for loom work
+#   - THIS script ...................... the cloud/k8s/IaC stack + extra runtimes
+#                                        that loom's onboarding leaves out
+#
+# Run mac_setup_personal.sh first (it bootstraps Homebrew). Idempotent: safe to
+# re-run; failing steps are recorded and skipped, then summarized at the end.
+
+set -uo pipefail
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mWARN:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+has()  { command -v "$1" >/dev/null 2>&1; }
+
+FAILED_COUNT=0
+FAILED_LIST=""
+note_fail() {
+  warn "$1 — continuing with the remaining steps."
+  FAILED_COUNT=$((FAILED_COUNT + 1))
+  FAILED_LIST="${FAILED_LIST}  - $1\n"
+}
+
+brew_install() {
+  local formula="$1"
+  brew list "${formula##*/}" >/dev/null 2>&1 || brew install "$formula"
+}
+brew_install_cask() {
+  local cask="$1"
+  brew list --cask "${cask##*/}" >/dev/null 2>&1 || brew install --cask "$cask"
+}
+
+has brew || die "Homebrew not found. Run mac_setup_personal.sh first."
+
+# --- 1. Taps ------------------------------------------------------------------
+
+info "Step 1/5: taps"
+brew tap hashicorp/tap >/dev/null 2>&1 || note_fail "tap hashicorp/tap failed"
+
+# --- 2. Language runtimes -----------------------------------------------------
+# Node comes from loom's setup-dev-env.sh (pinned to 24.15 via nvm); nvm is
+# installed here too so it exists even if you skip the loom script. pnpm is also
+# installed by the loom script — kept here so a standalone work laptop has it.
+
+info "Step 2/5: language runtimes"
+WORK_RUNTIMES=(
+  nvm pnpm yarn
+  uv                # modern Python package/venv manager (replaces pipx+virtualenv)
+  go
+  python@3.13
+)
+for pkg in "${WORK_RUNTIMES[@]}"; do
+  brew_install "$pkg" || note_fail "brew install $pkg failed"
+done
+
+# Node via nvm, pinned to match loom's setup-dev-env.sh. Skip with NODE_VERSION=skip.
+NODE_VERSION="${NODE_VERSION:-24.15}"
+if [[ "$NODE_VERSION" != "skip" ]]; then
+  export NVM_DIR="$HOME/.nvm"
+  mkdir -p "$NVM_DIR"
+  NVM_SH="$(brew --prefix nvm 2>/dev/null)/nvm.sh"
+  if [[ -s "$NVM_SH" ]]; then
+    set +u
+    # shellcheck disable=SC1090
+    . "$NVM_SH"
+    if nvm install "$NODE_VERSION" && nvm alias default "$NODE_VERSION"; then
+      info "node $(node --version)"
+    else
+      note_fail "Node $NODE_VERSION install via nvm failed"
+    fi
+    set -u
+  else
+    note_fail "nvm.sh not found under $(brew --prefix nvm 2>/dev/null); skipped Node"
+  fi
+fi
+
+# --- 3. Kubernetes / cloud CLIs -----------------------------------------------
+# NOTE: gcloud-cli (next step) also ships a kubectl under its SDK bin dir. If you
+# install kubernetes-cli here too, make sure PATH ordering picks the one you want.
+
+info "Step 3/5: kubernetes tooling"
+WORK_K8S=(
+  kubernetes-cli   # kubectl (gcloud SDK also provides one — see note above)
+  helm
+  kustomize
+  argocd
+  cmctl
+  k9s
+)
+for pkg in "${WORK_K8S[@]}"; do
+  brew_install "$pkg" || note_fail "brew install $pkg failed"
+done
+
+# --- 4. Infrastructure as code ------------------------------------------------
+
+info "Step 4/5: infrastructure as code"
+WORK_IAC=(
+  hashicorp/tap/terraform
+  hashicorp/tap/packer
+)
+for pkg in "${WORK_IAC[@]}"; do
+  brew_install "$pkg" || note_fail "brew install $pkg failed"
+done
+
+# --- 5. Work casks ------------------------------------------------------------
+
+info "Step 5/5: work GUI apps"
+WORK_CASKS=(
+  gcloud-cli      # Google Cloud SDK (provides gcloud + a kubectl)
+  lens            # Kubernetes IDE
+)
+for cask in "${WORK_CASKS[@]}"; do
+  brew_install_cask "$cask" || note_fail "brew install --cask $cask failed"
+done
+
+# --- summary ------------------------------------------------------------------
+
+echo
+if [[ "$FAILED_COUNT" -gt 0 ]]; then
+  warn "Work setup finished with $FAILED_COUNT issue(s):"
+  printf '%b' "$FAILED_LIST" >&2
+  warn "The script is idempotent — fix the issues above and re-run it."
+else
+  info "All work setup steps completed."
+fi
+cat <<'DONE'
+
+Next: provision the loom dev loop with loom's onboarding script:
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/wvrdz/loom/main/scripts/setup-dev-env.sh)"
+(installs pnpm/just/direnv/tmux, Node 24.15, shll/fab, Docker, ghcr auth, clones loom)
+DONE
+
+[[ "$FAILED_COUNT" -eq 0 ]] || exit 1


### PR DESCRIPTION
Splits the monolithic bin/mac_setup.sh into two idempotent, shellcheck-clean scripts so personal config travels across all laptops while work tooling stays on the work machine.

- mac_setup_personal.sh: Homebrew bootstrap, screenshots symlink, oh-my-zsh, ~/bin + myfiles, downloads cron, plus personal CLI (ripgrep/fzf/tree/htop/ stow/direnv/gh/doppler/yq...) and apps (Chrome, Firefox, 1Password + Bitwarden, Obsidian, Notion, Ghostty, Shottr, Secretive...).
- mac_setup_work.sh: cloud/k8s/IaC + extra runtimes (uv/yarn/go/python@3.13, kubectl/helm/kustomize/argocd/cmctl/k9s, terraform/packer via hashicorp/tap, gcloud-cli + Lens). Defers the loom dev loop to loom's setup-dev-env.sh.

Cleanups vs the old script:
- drops the dead Keybase/dotfiles + .ssh block (now Secretive + Doppler/1Pw)
- drops 1clipboard (cask removed upstream) and unlox; de-dups terminal-notifier
- fixes casks that were being installed as formulae (array-based install)
- replaces the broken crontab MAILTO logic with an append-once block
- powerlevel10k intentionally not provisioned (per preference)

Old mac_setup.sh kept with a deprecation header until the split is validated.